### PR TITLE
Make more backend generic, add precommit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,10 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea/
+
+# errbot specific folders/files
+config.py
+data/


### PR DESCRIPTION
This PR:
* adds pre-commit hooks to make sure code is linted and basic sanity checks are run on each commit
* Makes this code backend independent and offers a way for backends to have special features
** Currently implements a feature for the slack backend that sets a Channel's Topic to the topic of the day